### PR TITLE
Investigate woof wallet slow loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 </head>
 <body>
     <!-- Loading Screen -->
-    <div id="loading_screen" class="screen">
+    <div id="loading_screen" class="screen active">
         <div class="loading-container">
             <div class="loading-spinner"></div>
             <h2>Loading Woof Wallet...</h2>

--- a/js/app.js
+++ b/js/app.js
@@ -16,6 +16,19 @@ class WoofWalletApp {
         try {
             console.log('🐕 Initializing Woof Wallet...');
             
+            // Set up fail-safe to hide loading screen after maximum 10 seconds
+            const loadingFailSafe = setTimeout(() => {
+                console.warn('⚠️ Loading screen fail-safe triggered - hiding loading screen');
+                const loadingScreen = document.getElementById('loading_screen');
+                if (loadingScreen && loadingScreen.classList.contains('active')) {
+                    loadingScreen.classList.remove('active');
+                    // Show error or try to determine initial screen again
+                    if (!this.initialized) {
+                        this.handleInitializationError(new Error('Initialization timed out'));
+                    }
+                }
+            }, 10000);
+            
             // Initialize UI first
             ui.init();
             
@@ -24,6 +37,9 @@ class WoofWalletApp {
             
             // Determine initial screen based on wallet state
             await this.determineInitialScreen();
+            
+            // Clear the fail-safe timer since initialization completed
+            clearTimeout(loadingFailSafe);
             
             this.initialized = true;
             console.log('🐕 Woof Wallet initialized successfully!');
@@ -40,25 +56,35 @@ class WoofWalletApp {
      */
     async determineInitialScreen() {
         try {
+            console.log('🔍 Determining initial screen...');
+            console.log('Terms accepted:', wallet.acceptedTerms);
+            console.log('Wallet credentials exist:', !!wallet.credentials);
+            
             // Check if terms are accepted
             if (!wallet.acceptedTerms) {
+                console.log('➡️ Showing terms screen');
                 ui.showTermsScreen();
                 return;
             }
 
             // Check if wallet exists
             if (!wallet.credentials) {
+                console.log('➡️ Showing setup screen');
                 ui.showSetupScreen();
                 return;
             }
 
             // Wallet exists, show main wallet screen
+            console.log('➡️ Showing wallet screen');
             ui.showWalletScreen();
+            console.log('✅ Wallet screen should now be visible');
             
             // Refresh wallet data in background
             setTimeout(async () => {
                 try {
+                    console.log('🔄 Starting background wallet refresh...');
                     await ui.handleRefresh();
+                    console.log('✅ Background wallet refresh completed');
                 } catch (error) {
                     console.error('Failed to refresh wallet data on startup:', error);
                 }

--- a/js/ui.js
+++ b/js/ui.js
@@ -224,10 +224,13 @@ class WalletUI {
      * Show a specific screen
      */
     showScreen(screenId) {
+        console.log(`🖥️ Switching to screen: ${screenId}`);
+        
         // Hide all screens
         const screens = document.querySelectorAll('.screen');
         screens.forEach(screen => {
             screen.classList.remove('active');
+            console.log(`❌ Hiding screen: ${screen.id}`);
         });
 
         // Show target screen
@@ -235,6 +238,9 @@ class WalletUI {
         if (targetScreen) {
             targetScreen.classList.add('active');
             this.currentScreen = screenId;
+            console.log(`✅ Showing screen: ${screenId}`);
+        } else {
+            console.error(`❌ Screen not found: ${screenId}`);
         }
     }
 
@@ -305,6 +311,15 @@ class WalletUI {
         this.showScreen('wallet_screen');
         this.updateWalletDisplay();
         this.switchTab('overview');
+        
+        // Extra safety check to ensure loading screen is hidden
+        setTimeout(() => {
+            const loadingScreen = document.getElementById('loading_screen');
+            if (loadingScreen && loadingScreen.classList.contains('active')) {
+                console.warn('⚠️ Loading screen still active after wallet screen shown - force hiding');
+                loadingScreen.classList.remove('active');
+            }
+        }, 100);
     }
 
     /**

--- a/styles.css
+++ b/styles.css
@@ -40,10 +40,13 @@ body {
 
 /* Loading Screen */
 #loading_screen {
-    display: flex;
     align-items: center;
     justify-content: center;
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+
+#loading_screen.active {
+    display: flex;
 }
 
 .loading-container {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes Woof Wallet getting stuck on the loading screen by correcting CSS specificity and enhancing screen transition logic.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The primary issue was a CSS specificity conflict where `#loading_screen`'s `display: flex` rule overrode the general `.screen`'s `display: none`, preventing the loading screen from hiding. This PR resolves the CSS, ensures the loading screen is initially active, and adds fail-safe timeouts and enhanced logging for more robust screen management.

---
<a href="https://cursor.com/background-agent?bcId=bc-8278a5f3-ca12-45f9-a833-8a4321805f36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8278a5f3-ca12-45f9-a833-8a4321805f36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>