### PR TITLE
Fix wallet ui hide all screens error

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -233,17 +233,24 @@ class WalletUI {
     }
 
     /**
+     * Hide all screens
+     */
+    hideAllScreens() {
+        const screens = document.querySelectorAll('.screen');
+        screens.forEach(screen => {
+            screen.classList.remove('active');
+            console.log(`❌ Hiding screen: ${screen.id}`);
+        });
+    }
+
+    /**
      * Show a specific screen
      */
     showScreen(screenId) {
         console.log(`🖥️ Switching to screen: ${screenId}`);
         
         // Hide all screens
-        const screens = document.querySelectorAll('.screen');
-        screens.forEach(screen => {
-            screen.classList.remove('active');
-            console.log(`❌ Hiding screen: ${screen.id}`);
-        });
+        this.hideAllScreens();
 
         // Show target screen
         const targetScreen = document.getElementById(screenId);


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Create `hideAllScreens` method and refactor `showScreen` to fix `TypeError: this.hideAllScreens is not a function`.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The error occurred because `showPasswordSetup` and `handleWalletLock` were attempting to call a non-existent `this.hideAllScreens()` method. This PR extracts the common screen hiding logic from `showScreen` into a new `hideAllScreens` method, resolving the runtime error and improving code reusability.

---
<a href="https://cursor.com/background-agent?bcId=bc-538d7af7-d8d4-4617-9592-8d439a29f74e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-538d7af7-d8d4-4617-9592-8d439a29f74e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>