### PR TITLE
Initialize and test woof wallet

### DIFF
--- a/js/keyboard-shortcuts.js
+++ b/js/keyboard-shortcuts.js
@@ -171,8 +171,8 @@ class KeyboardShortcuts {
 
   refreshBalance() {
     // Refresh wallet balance
-    if (window.wallet && typeof window.wallet.updateBalance === 'function') {
-      window.wallet.updateBalance();
+    if (window.wallet && typeof window.wallet.refreshBalance === 'function') {
+      window.wallet.refreshBalance();
       this.showNotification('Balance refreshed', 'success');
     }
   }

--- a/js/wallet.js
+++ b/js/wallet.js
@@ -708,6 +708,13 @@ class WoofWallet {
     }
 
     /**
+     * Get current wallet balance
+     */
+    getBalance() {
+        return this.balance;
+    }
+
+    /**
      * Calculate available balance for sending (excluding inscription UTXOs)
      */
     async getAvailableBalance() {


### PR DESCRIPTION
Add `getBalance()` method to `WoofWallet` and correct balance refresh call to resolve `TypeError`.

The `TypeError: wallet.getBalance is not a function` occurred because the `WoofWallet` class was missing the `getBalance()` method, which was being called by the UI. Additionally, a call to `wallet.updateBalance()` in `keyboard-shortcuts.js` was corrected to `wallet.refreshBalance()`, which is the existing and correct method for refreshing the wallet balance.

---
<a href="https://cursor.com/background-agent?bcId=bc-97ef7f0d-061f-4668-bb9f-8718bd430a40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97ef7f0d-061f-4668-bb9f-8718bd430a40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>